### PR TITLE
Add g:vim_man_man_cmd to change man command

### DIFF
--- a/autoload/man/helpers.vim
+++ b/autoload/man/helpers.vim
@@ -65,11 +65,15 @@ endfunction
 " }}}
 " man#helpers#load_manpage_text {{{1
 
+if !exists('g:vim_man_man_cmd')
+  let g:vim_man_man_cmd='/usr/bin/man'
+endif
+
 function! man#helpers#load_manpage_text(page, section)
   setlocal modifiable
   silent keepj norm! 1GdG
   let $MANWIDTH = man#helpers#manwidth()
-  silent exec 'r!/usr/bin/man '.man#helpers#get_cmd_arg(a:section, a:page). ' 2>/dev/null | col -b'
+  silent exec 'r!'.g:vim_man_man_cmd.' '.man#helpers#get_cmd_arg(a:section, a:page). ' 2>/dev/null | col -b'
   call s:remove_blank_lines_from_top_and_bottom()
   setlocal filetype=man
   setlocal nomodifiable


### PR DESCRIPTION
some users may want to change man command.
for example

```
let g:vim_man_man_cmd = 'LANG=ja_JP.UTF-8 /usr/bin/man'
```