### PR TITLE
Fix mappings causing infinite loop in some cases

### DIFF
--- a/autoload/man.vim
+++ b/autoload/man.vim
@@ -40,6 +40,9 @@ function! man#get_page(split_type, ...)
 endfunction
 
 function! s:manpage_exists(sect, page)
+  if a:page ==# ''
+    return 0
+  endif
   let find_arg = man#helpers#find_arg()
   let where = system('/usr/bin/man '.find_arg.' '.man#helpers#get_cmd_arg(a:sect, a:page))
   if where !~# '^\s*/'

--- a/autoload/man/helpers.vim
+++ b/autoload/man/helpers.vim
@@ -76,10 +76,10 @@ function! man#helpers#load_manpage_text(page, section)
 endfunction
 
 function! s:remove_blank_lines_from_top_and_bottom()
-  while getline(1) =~ '^\s*$'
+  while line('$') > 1 && getline(1) =~ '^\s*$'
     silent keepj norm! ggdd
   endwhile
-  while getline('$') =~ '^\s*$'
+  while line('$') > 1 && getline('$') =~ '^\s*$'
     silent keepj norm! Gdd
   endwhile
   silent keepj norm! gg


### PR DESCRIPTION
The `<Plug>` mappings in `plugin/man.vim` and some of the mappings
specific to man page buffers (in fewer cases) can cause an infinite loop
in the `remove_blank_lines_from_top_and_bottom` function.

This can happen when `<cword>` expands to the empty string inside
`man#get_page_from_cword` or to anything else that will cause the
function to call `man#get_page` with the empty string as the last
argument.  E.g.: use `K` inside a man page buffer while the cursor is on
an empty line.

On my system, `manpage_exists` will return `1` because the output of
`man -w` without extra arguments
(`/usr/local/man:/usr/local/share/man:/usr/share/man` here) looks like a
man page to it.  `man#helpers#load_manpage_text` is then called with two
empty strings and `r!/usr/bin/man  2>/dev/null | col -b` leaves the new
buffer empty.  Finally, `remove_blank_lines_from_top_and_bottom` goes
into an infinite loop of trying to remove the only line in the buffer.