### PR TITLE
add new Tman command to open manual in new tab

### DIFF
--- a/autoload/man.vim
+++ b/autoload/man.vim
@@ -153,7 +153,9 @@ function! s:get_new_or_existing_man_window(split_type)
     if &filetype != 'man'
       if a:split_type == 'vertical'
         vnew
-      else
+      elseif a:split_type == 'tab'
+        tabnew
+      elseif a:split_type != 'only' || &modified
         new
       endif
     endif

--- a/plugin/man.vim
+++ b/plugin/man.vim
@@ -6,9 +6,10 @@ let g:loaded_man = 1
 let s:save_cpo = &cpo
 set cpo&vim
 
-command! -nargs=* -bar -complete=customlist,man#completion#run Man  call man#get_page('horizontal', <f-args>)
+command! -nargs=* -bar -complete=customlist,man#completion#run Man  call man#get_page('only', <f-args>)
 command! -nargs=* -bar -complete=customlist,man#completion#run Sman call man#get_page('horizontal', <f-args>)
 command! -nargs=* -bar -complete=customlist,man#completion#run Vman call man#get_page('vertical',   <f-args>)
+command! -nargs=* -bar -complete=customlist,man#completion#run Tman call man#get_page('tab',   <f-args>)
 
 command! -nargs=+ -bang Mangrep call man#grep#run(<bang>0, <f-args>)
 


### PR DESCRIPTION
This pull do two things:

1. Add `Tman` command to open manual page in new tab;
2. Change the default `Man` command behaviour: if current buffer is unmodified, just open manual in current buffer.