### PR TITLE
Stop buildin man plugin from shadowing `:Man`.

### DIFF
--- a/plugin/man.vim
+++ b/plugin/man.vim
@@ -2,6 +2,7 @@ if exists('g:loaded_vim_utils_man') && g:loaded_vim_utils_man
   finish
 endif
 let g:loaded_vim_utils_man = 1
+let g:loaded_man = 1 " stop the buildin man plugin from loading
 
 let s:save_cpo = &cpo
 set cpo&vim


### PR DESCRIPTION
The `man.vim` file that is shipped with nvim is shadowing `:Man`. This turns of completions for the command. Is this also the case for you? (Try `:verbose command Man` to see where the command was defined.)

This PR will bring back the `g:loaded_man` variable to stop the buildin `man.vim` from being sourced. This fixes the issue for me.

cc @sakhnik, #33, #34